### PR TITLE
Added max concurrently sick counter

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -191,6 +191,7 @@
         <div>Recovered<br /><span id="recovered">0</span></div>
         <div>Sick<br /><span id="infected">0</span></div>
         <div id="death-count">Deaths<br /><span id="death">0</span></div>
+        <div>Max Concurrently Sick<br /><span id="max-concurrent-infected">0</span></div>
       </div>
 
       <svg id="graph" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="50" width="100%" aria-labelledby="Graph of virus spread" role="img">

--- a/src/index.html
+++ b/src/index.html
@@ -97,10 +97,12 @@
     #count {
       display: flex;
       justify-content: space-around;
+      flex-wrap: wrap;
     }
 
     #count div {
       margin-bottom: 16px;
+      padding: 0 10px;
     }
 
     #count span {

--- a/src/options.js
+++ b/src/options.js
@@ -28,11 +28,17 @@ export const STATES = {
   death: 'death'
 }
 
+export const COUNTERS = {
+  ...STATES,
+  'max-concurrent-infected': 'max-concurrent-infected'
+}
+
 export const STARTING_BALLS = {
   [STATES.infected]: 1,
   [STATES.well]: 199,
   [STATES.recovered]: 0,
-  [STATES.death]: 0
+  [STATES.death]: 0,
+  'max-concurrent-infected': 0
 }
 
 export const RUN = {

--- a/src/results.js
+++ b/src/results.js
@@ -3,6 +3,7 @@ import {
   RUN,
   TOTAL_TICKS,
   STATES,
+  COUNTERS,
   resetRun
 } from './options.js'
 
@@ -17,7 +18,7 @@ const matchMedia = window.matchMedia('(min-width: 800px)')
 let isDesktop = matchMedia.matches
 
 const domElements = Object.fromEntries(
-  Object.keys(STATES).map(state => {
+  Object.keys(COUNTERS).map(state => {
     const el = document.getElementById(state)
     if (el) {
       el.parentNode.style = `color: ${COLORS[state]}`
@@ -54,6 +55,11 @@ export const resetValues = (isDesktopNewValue = isDesktop) => {
 
 export const updateCount = () => {
   if (RUN.tick < TOTAL_TICKS) {
+    // calculate max concurrent infected
+    if (RUN.results[STATES.infected] > RUN.results['max-concurrent-infected']) {
+      RUN.results['max-concurrent-infected']++
+    }
+
     Object.entries(domElements).forEach(([state, domElement]) => {
       if (domElement) {
         domElement.innerText = RUN.results[state]


### PR DESCRIPTION
'Max Concurrently Sick' counter shows the highest number of concurrently sick people at once. This acts as an additional insight & offers a conclusion at the end of the simulation. Such a counter also allows for better accessibility for screen-readers.