### PR TITLE
Swapped recovered & infected colors

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -16,8 +16,8 @@ export const DESKTOP_CANVAS_SIZE = {
 export const BALL_RADIUS = 5
 export const COLORS = {
   death: '#c50000',
-  recovered: '#D88DBC',
-  infected: '#5ABA4A',
+  recovered: '#5ABA4A',
+  infected: '#D88DBC',
   well: '#63C8F2'
 }
 


### PR DESCRIPTION
I've swapped colors for sick & recovered states as it makes more sense for sick to be denoted by pink and recovered to be denoted by green instead of vice-versa.