### PR TITLE
Removed Redundant Trigonometric Functions

### DIFF
--- a/src/collisions.js
+++ b/src/collisions.js
@@ -1,9 +1,9 @@
 const { hypot } = Math
 
 export const calculateChangeDirection = ({ dx, dy }) => {
-  const hyp = Math.hypot(dx, dy);
-  const ax = dy / hyp;
-  const ay = dx / hyp
+  const hyp = hypot(dx, dy);
+  const ax = dx / hyp;
+  const ay = dy / hyp
   return { ax, ay }
 }
 

--- a/src/collisions.js
+++ b/src/collisions.js
@@ -1,13 +1,13 @@
-const { atan2, cos, sin, sqrt } = Math
+const { hypot } = Math
 
 export const calculateChangeDirection = ({ dx, dy }) => {
-  const angle = atan2(dy, dx)
-  const ax = cos(angle)
-  const ay = sin(angle)
+  const hyp = Math.hypot(dx, dy);
+  const ax = dy / hyp;
+  const ay = dx / hyp
   return { ax, ay }
 }
 
 export const checkCollision = ({ dx, dy, diameter }) => {
-  const distance = sqrt(dx * dx + dy * dy)
-  return distance < diameter
+  const distance2 = dx * dx + dy * dy
+  return distance2 < diameter * diameter
 }


### PR DESCRIPTION
The file `collisions.js` does some redundant work by computing `atan` and then computing `sin` and `cos`. Instead, I used the function `hypot` which returns `sqrt(x*x + y*y)`.

Also the computation of `sqrt` is expensive, so it's best to be avoided.